### PR TITLE
Fix for locales and raw html output in settings

### DIFF
--- a/linkit/templates/_fieldtype/settings.html
+++ b/linkit/templates/_fieldtype/settings.html
@@ -43,7 +43,7 @@
 	}, '<p class="error">' ~ "No entry sources exist yet."|t ~ '</p>') }}
 {% endif %}
 
-{{ entryTargetLocaleField }}
+{{ entryTargetLocaleField | raw }}
 
 {% if assetSources %}
 	{{ forms.checkboxSelectField({
@@ -75,5 +75,5 @@
 	}, '<p class="error">' ~ "No category sources exist yet."|t ~ '</p>') }}
 {% endif %}
 
-{{ categoryTargetLocaleField }}
+{{ categoryTargetLocaleField | raw }}
 


### PR DESCRIPTION
There's currently an issue when using this field on a site with locales enabled. When creating a new Linkit field, there's some raw HTML outputted to the field settings, as below:

![screencapture-craft25-craft-dev-office-settings-fields-edit-599-1456645181157](https://cloud.githubusercontent.com/assets/1221575/13378081/c45fc4c4-de4b-11e5-80a1-8509dd0f2b09.png)

With this pull request, it will simply output this HTML properly, as below:

![screencapture-craft25-craft-dev-office-settings-fields-edit-599-1456645204174](https://cloud.githubusercontent.com/assets/1221575/13378079/aca65780-de4b-11e5-84c2-ae27f3194a1a.png)