### PR TITLE
Allow plugins to add their own Element Types

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,101 @@ or specific element types
     {{ linkItField.custom }} use {{ linkItField.url }} instead.
     {{ linkItField.tel }} use {{ linkItField.url }} instead.
 
+
+### Hooks
+
+There are two hooks that allow plugins to add their own Element Types to Link It:
+
+#### `linkit_registerElementTypes`
+
+Registers the ElementType(s) with LinkIt and provides all the data needed for the field settings.
+
+It should return an array of element types you want to register and should be in the following format:
+
+```php
+/**
+ * @return array
+ */
+public function linkit_registerElementTypes()
+{
+
+  return array(
+   'my_element' => array(
+     'name'                   => Craft::t('My Element'),
+     'pluralName'             => Craft::t('My Elements'),
+     'selectionLabelDefault'  => Craft::t('Select an element'),
+     'emptyInputErrorMessage' => Craft::t('Please select an element'),
+     'elementType'            => 'MyPlugin_MyElement',
+     'sources' => array(
+       array(
+         'label' => Craft::t('All of my elements'),
+         'value' => '*'
+       ),
+       array(
+         'label' => Craft::t('Element source 1'),
+         'value' => 'myElementGroup:1'
+       ),
+       array(
+         'label' => Craft::t('Element source 2'),
+         'value' => 'myElementGroup:2'
+       )
+     )
+   )
+  ),
+  'my_other_element' => array(
+    ...
+  );
+
+}
+```
+
+#### `linkit_getElementData`
+
+Fetches the element data for a given `$type` and `$id`:
+
+```php
+/**
+ * @param  string $type
+ * @param  int    $id
+ * @return array|false
+ */
+public function linkit_getElementData($type, $id)
+{
+
+  // Return false if there is no `$type` or `$id` set
+  if (!$type || !$id) {
+    return false;
+  }
+
+  switch ($type) {
+    case 'my_element':
+      $myElement = craft()->myPlugin_myElements->getMyElementById($id);
+
+      if ($myElement) {
+        return array(
+          'url'     => $myElement->getUrl(),
+          'text'    => $myElement->title,
+          'element' => $myElement
+        );
+      } else {
+        // There was no element, so be sure to return false
+        return false;
+      }
+      break;
+
+    case 'my_other_element':
+      ...
+      break;
+
+    // We don’t want to return anything for unsupported types
+    default:
+      return false;
+      break;
+  }
+
+}
+```
+
 ## FruitLinkIt Roadmap
 
 Some things to do, and ideas for potential features:

--- a/fruitlinkit/fieldtypes/FruitLinkItFieldType.php
+++ b/fruitlinkit/fieldtypes/FruitLinkItFieldType.php
@@ -106,22 +106,26 @@ class FruitLinkItFieldType extends BaseFieldType
 
         // Allow plugins to add their own Element Select settings
         $thirdPartyElementSettings = craft()->fruitLinkIt->getThirdPartyElementSettings();
+
         foreach ($thirdPartyElementSettings as $key => $thirdPartyElementSetting) {
+            $data = false;
+            if ($value) {
+              $data = $value->getThirdPartyTypeData($key);
+            }
 
-          $data = $value->getThirdPartyTypeData($key);
+            $elementSelectSettings[$key] = array(
+              'elementType' => new ElementTypeVariable( craft()->elements->getElementType($thirdPartyElementSetting['elementType']) ),
+              'elements' => $value && $data && $data['element'] ? array($data['element']) : null,
+              'sources' => $settings[$key.'Sources'],
+              'criteria' => array(
+                  'status' => null,
+              ),
+              'sourceElementId' => ( isset($this->element->id) ? $this->element->id : null ),
+              'limit' => 1,
+              'addButtonLabel' => Craft::t($settings[$key.'SelectionLabel']),
+              'storageKey' => 'field.'.$this->model->id
+            );
 
-          $elementSelectSettings[$key] = array(
-            'elementType' => new ElementTypeVariable( craft()->elements->getElementType($thirdPartyElementSetting['elementType']) ),
-            'elements' => $value && $data['element'] ? array($data['element']) : null,
-            'sources' => $settings[$key.'Sources'],
-            'criteria' => array(
-                'status' => null,
-            ),
-            'sourceElementId' => ( isset($this->element->id) ? $this->element->id : null ),
-            'limit' => 1,
-            'addButtonLabel' => Craft::t($settings[$key.'SelectionLabel']),
-            'storageKey' => 'field.'.$this->model->id
-          );
         }
 
         // Render Field
@@ -223,7 +227,7 @@ class FruitLinkItFieldType extends BaseFieldType
 		);
 
     // Give plugins a chance to add their own types
-    $allPluginLinkItTypes = craft()->plugins->call('linkit_registerTypes');
+    $allPluginLinkItTypes = craft()->plugins->call('linkit_registerElementTypes');
 
     foreach ($allPluginLinkItTypes as $pluginLinkItType)
     {

--- a/fruitlinkit/fieldtypes/FruitLinkItFieldType.php
+++ b/fruitlinkit/fieldtypes/FruitLinkItFieldType.php
@@ -107,16 +107,16 @@ class FruitLinkItFieldType extends BaseFieldType
         // Allow plugins to add their own Element Select settings
         $thirdPartyElementSettings = craft()->fruitLinkIt->getThirdPartyElementSettings();
 
-        foreach ($thirdPartyElementSettings as $key => $thirdPartyElementSetting) {
+        foreach ($thirdPartyElementSettings as $thirdPartyHandle => $thirdPartyElementSettingArray) {
             $data = false;
             if ($value) {
-              $data = $value->getThirdPartyTypeData($key);
+              $data = $value->getThirdPartyTypeData($thirdPartyHandle);
             }
 
-            $elementSelectSettings[$key] = array(
-              'elementType' => new ElementTypeVariable( craft()->elements->getElementType($thirdPartyElementSetting['elementType']) ),
+            $elementSelectSettings[$thirdPartyHandle] = array(
+              'elementType' => new ElementTypeVariable( craft()->elements->getElementType($thirdPartyElementSettingArray['elementType']) ),
               'elements' => $value && $data && $data['element'] ? array($data['element']) : null,
-              'sources' => $settings[$key.'Sources'],
+              'sources' => $settings[$thirdPartyHandle.'Sources'],
               'criteria' => array(
                   'status' => null,
               ),

--- a/fruitlinkit/fieldtypes/FruitLinkItFieldType.php
+++ b/fruitlinkit/fieldtypes/FruitLinkItFieldType.php
@@ -104,15 +104,33 @@ class FruitLinkItFieldType extends BaseFieldType
             )
         );
 
-        // XXX Allow plugins to add their own Element Select settings
+        // Allow plugins to add their own Element Select settings
+        $thirdPartyElementSettings = craft()->fruitLinkIt->getThirdPartyElementSettings();
+        foreach ($thirdPartyElementSettings as $key => $thirdPartyElementSetting) {
 
-		// Render Field
-    	return craft()->templates->render('fruitlinkit/_fieldtype/input', array(
+          $data = $value->getThirdPartyTypeData($key);
+
+          $elementSelectSettings[$key] = array(
+            'elementType' => new ElementTypeVariable( craft()->elements->getElementType($thirdPartyElementSetting['elementType']) ),
+            'elements' => $value && $data['element'] ? array($data['element']) : null,
+            'sources' => $settings[$key.'Sources'],
+            'criteria' => array(
+                'status' => null,
+            ),
+            'sourceElementId' => ( isset($this->element->id) ? $this->element->id : null ),
+            'limit' => 1,
+            'addButtonLabel' => Craft::t($settings[$key.'SelectionLabel']),
+            'storageKey' => 'field.'.$this->model->id
+          );
+        }
+
+        // Render Field
+        return craft()->templates->render('fruitlinkit/_fieldtype/input', array(
             'name'  => $name,
             'value' => $value,
             'settings' => $settings,
             'types' => $types,
-            'elementSelectSettings' => $elementSelectSettings,
+            'elementSelectSettings' => $elementSelectSettings
         ));
     }
 

--- a/fruitlinkit/fieldtypes/FruitLinkItFieldType.php
+++ b/fruitlinkit/fieldtypes/FruitLinkItFieldType.php
@@ -13,14 +13,15 @@ class FruitLinkItFieldType extends BaseFieldType
         return array(AttributeType::Mixed);
     }
 
-	public function getSettingsHtml()
-	{
-		return craft()->templates->render('fruitlinkit/_fieldtype/settings', array(
-			'settings'             		=> $this->getSettings(),
-            'types' 			   		=> $this->_getAvaiableLinkItTypes(),
-            'elementSources'            => craft()->fruitLinkIt->getLinkItElementSources(),
-		));
-	}
+    public function getSettingsHtml()
+    {
+        return craft()->templates->render('fruitlinkit/_fieldtype/settings', array(
+          'settings'                  => $this->getSettings(),
+          'types'                     => $this->_getAvaiableLinkItTypes(),
+          'elementSources'            => craft()->fruitLinkIt->getLinkItElementSources(),
+          'thirdPartyElementSettings' => craft()->fruitLinkIt->getThirdPartyElementSettings(),
+        ));
+    }
 
     public function getInputHtml($name, $value)
     {
@@ -102,6 +103,8 @@ class FruitLinkItFieldType extends BaseFieldType
                 'storageKey' => 'field.'.$this->model->id,
             )
         );
+
+        // XXX Allow plugins to add their own Element Select settings
 
 		// Render Field
     	return craft()->templates->render('fruitlinkit/_fieldtype/input', array(
@@ -191,7 +194,7 @@ class FruitLinkItFieldType extends BaseFieldType
 
     private function _getLinkItTypes()
 	{
-		return array(
+		$types = array(
 			'email' => Craft::t('Email Address'),
 			'tel' => Craft::t('Phone Number'),
 			'custom' => Craft::t('Custom URL'),
@@ -200,6 +203,16 @@ class FruitLinkItFieldType extends BaseFieldType
 			'asset' => Craft::t('Asset'),
       'product' => Craft::t('Product'),
 		);
+
+    // Give plugins a chance to add their own types
+    $allPluginLinkItTypes = craft()->plugins->call('linkit_registerTypes');
+
+    foreach ($allPluginLinkItTypes as $pluginLinkItType)
+    {
+      $types = array_merge($types, $pluginLinkItType);
+    }
+
+    return $types;
 	}
 
     private function _valueToModel($value, $settings = false)

--- a/fruitlinkit/models/FruitLinkIt_LinkModel.php
+++ b/fruitlinkit/models/FruitLinkIt_LinkModel.php
@@ -291,18 +291,15 @@ class FruitLinkIt_LinkModel extends BaseModel
 
     public function getThirdPartyTypeData($type)
     {
-
         if(!$this->_thirdPartyTypes[$type])
         {
             $id = is_array($this->value) ? $this->value[0] : false;
+
             if ($id)
             {
 
               // Allow plugins to define their own url and text data
-              $allPluginElements = craft()->plugins->call('linkit_getElementData', array(
-                  'id' => $id,
-                  'type' => $type
-              ));
+              $allPluginElements = craft()->plugins->call('linkit_getElementData', array($type, $id));
 
               foreach ($allPluginElements as $pluginElement)
               {

--- a/fruitlinkit/models/FruitLinkIt_LinkModel.php
+++ b/fruitlinkit/models/FruitLinkIt_LinkModel.php
@@ -119,8 +119,8 @@ class FruitLinkIt_LinkModel extends BaseModel
                 $url = 'mailto:'.$this->value;
                 break;
             default:
-                // Let plugins handle their own urls
-                $data = $this->getThirdPartyTypeData($this->type);
+                // Let third party elements handle their own urls
+                $data = $this->getThirdPartyElementData($this->type);
                 if (isset($data['url']))
                 {
                   $url = $data['url'];
@@ -175,8 +175,8 @@ class FruitLinkIt_LinkModel extends BaseModel
                 }
                 break;
             default:
-                // Let plugins handle their own text value if they want
-                $data = $this->getThirdPartyTypeData($this->type);
+                // Let third party elements handle their own text value if they want
+                $data = $this->getThirdPartyElementData($this->type);
                 if (isset($data['text']))
                 {
                   $text = $data['text'];
@@ -289,9 +289,9 @@ class FruitLinkIt_LinkModel extends BaseModel
         return $this->_product;
     }
 
-    public function getThirdPartyTypeData($type)
+    public function getThirdPartyElementData($type)
     {
-        if(!$this->_thirdPartyTypes[$type])
+        if(!isset($this->_thirdPartyTypes[$type]) || !$this->_thirdPartyTypes[$type])
         {
             $id = is_array($this->value) ? $this->value[0] : false;
 
@@ -312,7 +312,7 @@ class FruitLinkIt_LinkModel extends BaseModel
             }
 
         }
-        return $this->_thirdPartyTypes[$type];
+        return isset($this->_thirdPartyTypes[$type]) ? $this->_thirdPartyTypes[$type] : null;
     }
 
     public function validate($attributes = null, $clearErrors = true)
@@ -372,11 +372,10 @@ class FruitLinkIt_LinkModel extends BaseModel
             default:
               if($this->value == '')
               {
-                $thirdPartyElementSettings = craft()->fruitLinkIt->getThirdPartyElementSettings();
-                $thirdPartyElementSetting = $thirdPartyElementSettings[$this->type];
-                if (isset($thirdPartyElementSettings[$this->type]) && isset($thirdPartyElementSettings[$this->type]['emptyInputErrorMessage']))
+                $thirdPartyElementTypes = craft()->fruitLinkIt->getThirdPartyElementTypes();
+                if (isset($thirdPartyElementTypes[$this->type]) && isset($thirdPartyElementTypes[$this->type]['emptyInputErrorMessage']))
                 {
-                  $this->addError('value', $thirdPartyElementSettings[$this->type]['emptyInputErrorMessage']);
+                  $this->addError('value', $thirdPartyElementTypes[$this->type]['emptyInputErrorMessage']);
                 }
                 else
                 {

--- a/fruitlinkit/models/FruitLinkIt_LinkModel.php
+++ b/fruitlinkit/models/FruitLinkIt_LinkModel.php
@@ -369,7 +369,21 @@ class FruitLinkIt_LinkModel extends BaseModel
                 }
                 break;
 
-            // XXX: likely need something here when templating
+            default:
+              if($this->value == '')
+              {
+                $thirdPartyElementSettings = craft()->fruitLinkIt->getThirdPartyElementSettings();
+                $thirdPartyElementSetting = $thirdPartyElementSettings[$this->type];
+                if (isset($thirdPartyElementSettings[$this->type]) && isset($thirdPartyElementSettings[$this->type]['emptyInputErrorMessage']))
+                {
+                  $this->addError('value', $thirdPartyElementSettings[$this->type]['emptyInputErrorMessage']);
+                }
+                else
+                {
+                  $this->addError('value', Craft::t('Please select something.'));
+                }
+              }
+              break;
         }
 
         return !$this->hasErrors();

--- a/fruitlinkit/models/FruitLinkIt_LinkSettingsModel.php
+++ b/fruitlinkit/models/FruitLinkIt_LinkSettingsModel.php
@@ -72,7 +72,15 @@ class FruitLinkIt_LinkSettingsModel extends BaseModel
                 $this->addError('productSources', Craft::t('Please select at least 1 product source.'));
             }
 
-            // XXX: what do we do about this?
+            // Handle third party plugin settings errors
+            $thirdPartyElementSettings = craft()->fruitLinkIt->getThirdPartyElementSettings();
+            foreach ($thirdPartyElementSettings as $thirdPartyHandle => $thirdPartyElementSettingArray) {
+              if( in_array($thirdPartyHandle, $this->types) && $this[$thirdPartyHandle.'Sources'] == '')
+              {
+                  $this->addError($thirdPartyHandle.'Sources', Craft::t('Please select at least 1 '.strtolower($thirdPartyElementSettingArray['name']).' source.'));
+              }
+            }
+
         }
         else
         {

--- a/fruitlinkit/models/FruitLinkIt_LinkSettingsModel.php
+++ b/fruitlinkit/models/FruitLinkIt_LinkSettingsModel.php
@@ -16,7 +16,7 @@ class FruitLinkIt_LinkSettingsModel extends BaseModel
 {
     protected function defineAttributes()
     {
-        return array(
+        $attributes = array(
             'types' => AttributeType::Mixed,
             'allowCustomText' => AttributeType::Bool,
             'defaultText' => AttributeType::String,
@@ -34,6 +34,16 @@ class FruitLinkIt_LinkSettingsModel extends BaseModel
             'productSources' => AttributeType::Mixed,
             'productSelectionLabel' => array(AttributeType::String, 'default' => Craft::t('Select a product')),
         );
+
+        // Allow plugins to add their own attributes
+        $allPluginSettingsAttributes = craft()->plugins->call('linkit_getSettingsAttributes');
+
+        foreach ($allPluginSettingsAttributes as $pluginSettingsAttribute)
+        {
+            $attributes = array_merge($attributes, $pluginSettingsAttribute);
+        }
+
+        return $attributes;
     }
 
     public function validate($attributes = null, $clearErrors = true)
@@ -61,6 +71,8 @@ class FruitLinkIt_LinkSettingsModel extends BaseModel
             {
                 $this->addError('productSources', Craft::t('Please select at least 1 product source.'));
             }
+
+            // XXX: what do we do about this?
         }
         else
         {

--- a/fruitlinkit/models/FruitLinkIt_LinkSettingsModel.php
+++ b/fruitlinkit/models/FruitLinkIt_LinkSettingsModel.php
@@ -35,12 +35,12 @@ class FruitLinkIt_LinkSettingsModel extends BaseModel
             'productSelectionLabel' => array(AttributeType::String, 'default' => Craft::t('Select a product')),
         );
 
-        // Allow plugins to add their own attributes
-        $allPluginSettingsAttributes = craft()->plugins->call('linkit_getSettingsAttributes');
-
-        foreach ($allPluginSettingsAttributes as $pluginSettingsAttribute)
-        {
-            $attributes = array_merge($attributes, $pluginSettingsAttribute);
+        $thirdPartyElementSettings = craft()->fruitLinkIt->getThirdPartyElementSettings();
+        foreach ($thirdPartyElementSettings as $key => $thirdPartyElementSetting) {
+          $attributes = array_merge($attributes, array(
+            $key.'Sources' => AttributeType::Mixed,
+            $key.'SelectionLabel' => array(AttributeType::String, 'default' => $thirdPartyElementSetting['selectionLabelDefault'])
+          ));
         }
 
         return $attributes;

--- a/fruitlinkit/models/FruitLinkIt_LinkSettingsModel.php
+++ b/fruitlinkit/models/FruitLinkIt_LinkSettingsModel.php
@@ -35,11 +35,11 @@ class FruitLinkIt_LinkSettingsModel extends BaseModel
             'productSelectionLabel' => array(AttributeType::String, 'default' => Craft::t('Select a product')),
         );
 
-        $thirdPartyElementSettings = craft()->fruitLinkIt->getThirdPartyElementSettings();
-        foreach ($thirdPartyElementSettings as $key => $thirdPartyElementSetting) {
+        $thirdPartyElementTypes = craft()->fruitLinkIt->getThirdPartyElementTypes();
+        foreach ($thirdPartyElementTypes as $elementTypeHandle => $elementTypeConfig) {
           $attributes = array_merge($attributes, array(
-            $key.'Sources' => AttributeType::Mixed,
-            $key.'SelectionLabel' => array(AttributeType::String, 'default' => $thirdPartyElementSetting['selectionLabelDefault'])
+            $elementTypeHandle.'Sources' => AttributeType::Mixed,
+            $elementTypeHandle.'SelectionLabel' => array(AttributeType::String, 'default' => $elementTypeConfig['selectionLabelDefault'])
           ));
         }
 
@@ -72,12 +72,12 @@ class FruitLinkIt_LinkSettingsModel extends BaseModel
                 $this->addError('productSources', Craft::t('Please select at least 1 product source.'));
             }
 
-            // Handle third party plugin settings errors
-            $thirdPartyElementSettings = craft()->fruitLinkIt->getThirdPartyElementSettings();
-            foreach ($thirdPartyElementSettings as $thirdPartyHandle => $thirdPartyElementSettingArray) {
-              if( in_array($thirdPartyHandle, $this->types) && $this[$thirdPartyHandle.'Sources'] == '')
+            // Handle third party element errors
+            $thirdPartyElementTypes = craft()->fruitLinkIt->getThirdPartyElementTypes();
+            foreach ($thirdPartyElementTypes as $elementTypeHandle => $elementTypeConfig) {
+              if( in_array($elementTypeHandle, $this->types) && $this[$elementTypeHandle.'Sources'] == '')
               {
-                  $this->addError($thirdPartyHandle.'Sources', Craft::t('Please select at least 1 '.strtolower($thirdPartyElementSettingArray['name']).' source.'));
+                  $this->addError($elementTypeHandle.'Sources', Craft::t('Please select at least 1 '.strtolower($elementTypeConfig['name']).' source.'));
               }
             }
 

--- a/fruitlinkit/services/FruitLinkItService.php
+++ b/fruitlinkit/services/FruitLinkItService.php
@@ -35,6 +35,20 @@ class FruitLinkItService extends BaseApplicationComponent
         );
     }
 
+    // Gives plugins a chance to add their own element sources
+    public function getThirdPartyElementSettings()
+    {
+      $elementSettings = array();
+      $allPluginElementSettings = craft()->plugins->call('linkit_addElementSettings');
+
+      foreach ($allPluginElementSettings as $pluginElementSetting)
+      {
+        $elementSettings = array_merge($elementSettings, $pluginElementSetting);
+      }
+
+      return $elementSettings;
+    }
+
     private function _getElementSourcesWithUrls($type)
     {
         $elementType = craft()->elements->getElementType($type);

--- a/fruitlinkit/services/FruitLinkItService.php
+++ b/fruitlinkit/services/FruitLinkItService.php
@@ -35,18 +35,18 @@ class FruitLinkItService extends BaseApplicationComponent
         );
     }
 
-    // Gives plugins a chance to add their own element sources
-    public function getThirdPartyElementSettings()
+    // Gives plugins a chance to add their own element types
+    public function getThirdPartyElementTypes()
     {
-      $elementSettings = array();
-      $allPluginElementSettings = craft()->plugins->call('linkit_addElementSettings');
+      $elementTypesConfig = array();
+      $allPluginElementTypes = craft()->plugins->call('linkit_registerElementTypes');
 
-      foreach ($allPluginElementSettings as $pluginElementSetting)
+      foreach ($allPluginElementTypes as $pluginElementType)
       {
-        $elementSettings = array_merge($elementSettings, $pluginElementSetting);
+        $elementTypesConfig = array_merge($elementTypesConfig, $pluginElementType);
       }
 
-      return $elementSettings;
+      return $elementTypesConfig;
     }
 
     private function _getElementSourcesWithUrls($type)

--- a/fruitlinkit/templates/_fieldtype/input.html
+++ b/fruitlinkit/templates/_fieldtype/input.html
@@ -105,6 +105,7 @@
 
 		{# Custom types #}
 		{% for key, val in types if key not in ['','email','custom','tel','entry','asset','category','product'] %}
+		{% if elementSelectSettings[key] is defined %}
 		<div class="fruitlinkit-option fruitlinkit-{{ key }}{{ type != key ? ' hidden' }}">
 			{{ forms.elementSelectField({
 				id: name~key,
@@ -112,6 +113,7 @@
 				name: name~'['~key~']',
 			}|merge(elementSelectSettings[key])) }}
 		</div>
+		{% endif %}
 		{% endfor %}
 	</div>
 

--- a/fruitlinkit/templates/_fieldtype/input.html
+++ b/fruitlinkit/templates/_fieldtype/input.html
@@ -103,6 +103,16 @@
 		</div>
 		{% endif %}
 
+		{# Custom types #}
+		{% for key, val in types if key not in ['','email','custom','tel','entry','asset','category','product'] %}
+		<div class="fruitlinkit-option fruitlinkit-{{ key }}{{ type != key ? ' hidden' }}">
+			{{ forms.elementSelectField({
+				id: name~key,
+				class: name~key,
+				name: name~'['~key~']',
+			}|merge(elementSelectSettings[key])) }}
+		</div>
+		{% endfor %}
 	</div>
 
 	{# Text & Target #}

--- a/fruitlinkit/templates/_fieldtype/settings.html
+++ b/fruitlinkit/templates/_fieldtype/settings.html
@@ -145,3 +145,25 @@
 		instructions: "No entry sources exist yet."|t
 	}) }} #}
 {% endif %}
+
+{% for key, elementSettings in thirdPartyElementSettings %}
+	<hr>
+
+	{{ forms.checkboxSelectField({
+		label: elementSettings.name|t,
+		instructions: "Which sources do you want to select "~elementSettings.pluralName|lower~" from?"|t,
+		id: key~'Sources',
+		name: key~'Sources',
+		options: elementSettings.sources,
+		values: settings[key~'Sources'],
+		errors: settings.getErrors(key~'Sources'),
+	})}}
+
+	{{ forms.textField({
+		label: elementSettings.name~" Selection Label"|t,
+		instructions: "Enter the text you want to appear on the "~elementSettings.name|lower~" selection input."|t,
+		name: key~'SelectionLabel',
+		value: settings[key~'SelectionLabel']
+	}) }}
+
+{% endfor %}

--- a/fruitlinkit/templates/_fieldtype/settings.html
+++ b/fruitlinkit/templates/_fieldtype/settings.html
@@ -146,24 +146,24 @@
 	}) }} #}
 {% endif %}
 
-{% for key, elementSettings in thirdPartyElementSettings %}
+{% for elementTypeHandle, elementTypeConfig in thirdPartyElementTypes %}
 	<hr>
 
 	{{ forms.checkboxSelectField({
-		label: elementSettings.name|t,
-		instructions: "Which sources do you want to select "~elementSettings.pluralName|lower~" from?"|t,
-		id: key~'Sources',
-		name: key~'Sources',
-		options: elementSettings.sources,
-		values: settings[key~'Sources'],
-		errors: settings.getErrors(key~'Sources'),
+		label: elementTypeConfig.name|t,
+		instructions: "Which sources do you want to select "~elementTypeConfig.pluralName|lower~" from?"|t,
+		id: elementTypeHandle~'Sources',
+		name: elementTypeHandle~'Sources',
+		options: elementTypeConfig.sources,
+		values: settings[elementTypeHandle~'Sources'],
+		errors: settings.getErrors(elementTypeHandle~'Sources'),
 	})}}
 
 	{{ forms.textField({
-		label: elementSettings.name~" Selection Label"|t,
-		instructions: "Enter the text you want to appear on the "~elementSettings.name|lower~" selection input."|t,
-		name: key~'SelectionLabel',
-		value: settings[key~'SelectionLabel']
+		label: elementTypeConfig.name~" Selection Label"|t,
+		instructions: "Enter the text you want to appear on the "~elementTypeConfig.name|lower~" selection input."|t,
+		name: elementTypeHandle~'SelectionLabel',
+		value: settings[elementTypeHandle~'SelectionLabel']
 	}) }}
 
 {% endfor %}


### PR DESCRIPTION
Hey!

First of all - great plugin and thanks for all the hard work :)

I have added a couple of hooks to allow plugins to add their own Element Types to the field type. This addresses issue #37 that I raised recently.

I have tested it with my own plugins and added multiple Element Types from one plugin but have not tested multiple plugins.