### PR TITLE
Allow disabling the title attribute (htmlLink)

### DIFF
--- a/fruitlinkit/models/FruitLinkIt_LinkModel.php
+++ b/fruitlinkit/models/FruitLinkIt_LinkModel.php
@@ -62,7 +62,10 @@ class FruitLinkIt_LinkModel extends BaseModel
             {
                 foreach ($attributes as $attr => $value)
                 {
-                    $htmlLink .= ' '.$attr.'="'.$value.'"';
+                    if($value !== false)
+                    {
+                        $htmlLink .= ' '.$attr.'="'.$value.'"';
+                    }
                 }
             }
 


### PR DESCRIPTION
Passing title: false as an attribute to the htmlLink method will suppress the output of a title attribute.

See for why: https://silktide.com/i-thought-title-text-improved-accessibility-i-was-wrong/