### PR TITLE
Added customizable E-Mail Subject and Body

### DIFF
--- a/fruitlinkit/fieldtypes/FruitLinkItFieldType.php
+++ b/fruitlinkit/fieldtypes/FruitLinkItFieldType.php
@@ -251,6 +251,8 @@ class FruitLinkItFieldType extends BaseFieldType
             $link->value = $link->type ? $value[$link->type] : false;
             $link->customText = isset($value['customText']) ? $value['customText'] : false;
             $link->defaultText = $settings->defaultText;
+            $link->customEMailSubject = isset($value['customEMailSubject']) ? $value['customEMailSubject'] : false;
+            $link->customEMailBody = isset($value['customEMailBody']) ? $value['customEMailBody'] : false;
             $link->target = isset($value['target']) ? ($value['target'] ? '_blank' : false) : false;
 
 

--- a/fruitlinkit/models/FruitLinkIt_LinkModel.php
+++ b/fruitlinkit/models/FruitLinkIt_LinkModel.php
@@ -27,6 +27,8 @@ class FruitLinkIt_LinkModel extends BaseModel
             'value' => array(AttributeType::String, 'default' => false),
             'defaultText' => array(AttributeType::String, 'default' => false),
             'customText' => array(AttributeType::String, 'default' => false),
+            'customEMailSubject' => array(AttributeType::String, 'default' => false),
+            'customEMailBody' => array(AttributeType::String, 'default' => false),
             'target' => array(AttributeType::String, 'default' => false),
         );
     }
@@ -117,6 +119,10 @@ class FruitLinkIt_LinkModel extends BaseModel
                 break;
             case('email'):
                 $url = 'mailto:'.$this->value;
+                $extra = array_filter(['subject' => $this->customEMailSubject, 'body' => $this->customEMailBody]);
+                if (count($extra) > 0) {
+                    $url .= '?' . http_build_query($extra);
+                }
                 break;
             default:
                 // Let third party elements handle their own urls

--- a/fruitlinkit/models/FruitLinkIt_LinkModel.php
+++ b/fruitlinkit/models/FruitLinkIt_LinkModel.php
@@ -121,7 +121,7 @@ class FruitLinkIt_LinkModel extends BaseModel
                 $url = 'mailto:'.$this->value;
                 $extra = array_filter(['subject' => $this->customEMailSubject, 'body' => $this->customEMailBody]);
                 if (count($extra) > 0) {
-                    $url .= '?' . http_build_query($extra);
+                    $url .= '?' . http_build_query($extra, null, '&', PHP_QUERY_RFC3986);
                 }
                 break;
             default:

--- a/fruitlinkit/models/FruitLinkIt_LinkSettingsModel.php
+++ b/fruitlinkit/models/FruitLinkIt_LinkSettingsModel.php
@@ -21,6 +21,7 @@ class FruitLinkIt_LinkSettingsModel extends BaseModel
             'allowCustomText' => AttributeType::Bool,
             'defaultText' => AttributeType::String,
             'allowTarget' => AttributeType::Bool,
+            'emailExtras' => AttributeType::Mixed,
 
             'entrySources' => AttributeType::Mixed,
             'entrySelectionLabel' => array(AttributeType::String, 'default' => Craft::t('Select an entry')),

--- a/fruitlinkit/resources/css/linkit.css
+++ b/fruitlinkit/resources/css/linkit.css
@@ -24,3 +24,10 @@
 .fruitlinkit-settings {
 	clear:both;
 }
+
+.fruitlinkit-settings-emailextras {
+	margin: 10px 0 10px 0;
+	clear: both;
+	float: left;
+	width: 100%;
+}

--- a/fruitlinkit/resources/js/FruitLinkIt.js
+++ b/fruitlinkit/resources/js/FruitLinkIt.js
@@ -19,6 +19,7 @@
 
 			this.$optionsHolder = this.$field.find('.fruitlinkit-options');
 			this.$settingsHolder = this.$field.find('.fruitlinkit-settings');
+			this.$settingsHolderEMailExtras = this.$field.find('.fruitlinkit-settings-emailextras');
 			this.$options = this.$optionsHolder.find('.fruitlinkit-option');
 
 			this.addListener(this.$typeSelect, 'change', 'onChangeType');
@@ -28,6 +29,15 @@
 		{
 			var $select = $(e.currentTarget);
 			this.type = $select.val();
+
+			if(this.type === 'email')
+			{
+				this.$settingsHolderEMailExtras.show();
+			}
+			else
+			{
+				this.$settingsHolderEMailExtras.hide();
+			}
 
 			if(this.type === '')
 			{

--- a/fruitlinkit/templates/_fieldtype/input.html
+++ b/fruitlinkit/templates/_fieldtype/input.html
@@ -117,6 +117,36 @@
 		{% endfor %}
 	</div>
 
+	{# E-Mail Subject & Body #}
+	{% if settings.emailExtras|length > 0 and types.email is defined %}
+	<div class="fruitlinkit-settings-emailextras{{ type == '' ? ' hidden' }}">
+		{% if 'subject' in settings.emailExtras %}
+		<div class="fruit-field-column fruitlinkit-text">
+			{{ forms.textField({
+			label: 'E-Mail Subject'|t,
+			id: name~'customEMailSubject',
+			class: name~'customEMailSubject',
+			name: name~'[customEMailSubject]',
+			value: value.customEMailSubject is defined and value.customEMailSubject ? value.customEMailSubject
+			}) }}
+		</div>
+		{% endif %}
+
+		{% if 'body' in settings.emailExtras %}
+		<div class="fruit-field-column fruitlinkit-text">
+			{{ forms.textareaField({
+			label: 'E-Mail Body'|t,
+			rows: 5,
+			id: name~'customEMailBody',
+			class: name~'customEMailBody',
+			name: name~'[customEMailBody]',
+			value: value.customEMailBody is defined and value.customEMailBody ? value.customEMailBody
+			}) }}
+		</div>
+		{% endif %}
+	</div>
+	{% endif %}
+
 	{# Text & Target #}
 	{% if settings.allowCustomText or settings.allowTarget %}
 	<div class="fruitlinkit-settings{{ type == '' ? ' hidden' }}">

--- a/fruitlinkit/templates/_fieldtype/settings.html
+++ b/fruitlinkit/templates/_fieldtype/settings.html
@@ -13,6 +13,18 @@
 
 <hr>
 
+{{ forms.checkboxSelectField({
+	label: "E-Mail Settings"|t,
+	instructions: "Allow custom subject or body"|t,
+	id: 'emailExtras',
+	name: 'emailExtras',
+	options: { 'subject': 'Allow custom subject'|t, 'body': 'Allow custom body'|t },
+	values: settings.emailExtras,
+	showAllOption: false,
+})}}
+
+<hr>
+
 {{ forms.textField({
 	label: "Default Link Text"|t,
 	instructions: "Set a default value for this links text value, can be overridden if custom link text option is selected."|t,


### PR DESCRIPTION
When choosing the E-Mail type, allow the user to add a custom subject and/or body ([RFC 2368](http://www.ietf.org/rfc/rfc2368.txt)). The url in the output would then look something like this: `mailto:foo@bar.tld?subject=foo&body=bar`.

The query gets built with `http_build_query` so special characters, line breaks e.t.c are all according to the RFC.

**updated settings**
![linkitsettings](https://cloud.githubusercontent.com/assets/1340206/18199008/d5e26238-70fe-11e6-8f30-d9cbe3c2093b.png)

**updated input**
![linkitinput](https://cloud.githubusercontent.com/assets/1340206/18199010/d9e5b4ca-70fe-11e6-9b92-e1f7e903629f.png)
