### PR TITLE
Fixed validation of Custom URL

### DIFF
--- a/fruitlinkit/models/FruitLinkIt_LinkModel.php
+++ b/fruitlinkit/models/FruitLinkIt_LinkModel.php
@@ -335,7 +335,7 @@ class FruitLinkIt_LinkModel extends BaseModel
                 break;
 
             case('custom'):
-                if(!filter_var($this->value, FILTER_VALIDATE_URL) && $this->value == '#')
+                if($this->value == '' || !filter_var($this->value, FILTER_VALIDATE_URL) && $this->value[0] != '#')
                 {
                     $this->addError('value', Craft::t('Please enter a valid url.'));
                 }


### PR DESCRIPTION
Custom URL can't be empty. Accepts URLs and anchor links.

valid URL:
- valid FILTER_VALIDATE_URL
- anchor link (starting with #)
- not empty
