### PR TITLE
Ensure the type is still available

### DIFF
--- a/fruitlinkit/fieldtypes/FruitLinkItFieldType.php
+++ b/fruitlinkit/fieldtypes/FruitLinkItFieldType.php
@@ -44,7 +44,11 @@ class FruitLinkItFieldType extends BaseFieldType
     	{
 			foreach($settings['types'] as $type)
 			{
-				$types[$type] = $availableTypes[$type];
+				// Ensure the type is still available
+				if(array_key_exists($type, $availableTypes))
+				{
+					$types[$type] = $availableTypes[$type];
+				}
 			}
     	}
     	else


### PR DESCRIPTION
e.g. if a plugin previously providing a custom type has since been disabled or uninstalled.  Obviously an edge case, but one which we just ran into. :)