### PR TITLE
Restore FruitLinkIt_LinkModel::getThirdPartyElementData().

### DIFF
--- a/fruitlinkit/models/FruitLinkIt_LinkModel.php
+++ b/fruitlinkit/models/FruitLinkIt_LinkModel.php
@@ -291,6 +291,32 @@ class FruitLinkIt_LinkModel extends BaseModel
         return $this->_product;
     }
 
+    public function getThirdPartyElementData($type)
+    {
+        if(!isset($this->_thirdPartyTypes[$type]) || !$this->_thirdPartyTypes[$type])
+        {
+            $id = is_array($this->value) ? $this->value[0] : false;
+
+            if ($id)
+            {
+
+              // Allow plugins to define their own url and text data
+              $allPluginElements = craft()->plugins->call('linkit_getElementData', array($type, $id));
+
+              foreach ($allPluginElements as $pluginElement)
+              {
+                  if ($pluginElement)
+                  {
+                      $this->_thirdPartyTypes[$type] = $pluginElement;
+                  }
+              }
+
+            }
+
+        }
+        return isset($this->_thirdPartyTypes[$type]) ? $this->_thirdPartyTypes[$type] : null;
+    }
+
 
     public function validate($attributes = null, $clearErrors = true)
     {


### PR DESCRIPTION
It appears that as part of commit `00ecb16`, the method `getThirdPartyElementData()` was removed from `FruitLinkIt_LinkModel`. This was causing an error to be thrown even when outputting a "custom" linkit field value in the front-end.

Fixes: https://github.com/fruitstudios/LinkIt/issues/76

This commit restores that deletion.