### PR TITLE
Add rel="noopener noreferrer" to target="_blank"

### DIFF
--- a/fruitlinkit/models/FruitLinkIt_LinkModel.php
+++ b/fruitlinkit/models/FruitLinkIt_LinkModel.php
@@ -56,6 +56,10 @@ class FruitLinkIt_LinkModel extends BaseModel
             if( ( !is_array($attributes) || !array_key_exists('title', $attributes) ) && $this->target )
             {
                 $htmlLink .= ' target="'.$this->target.'"';
+                
+                if ($this->target == '_blank') {
+                    $htmlLink .= ' rel="noopener"';
+                }
             }
 
             // Add Attributes


### PR DESCRIPTION
rel="noopener noreferrer" should be added to links containing target="_blank" as a precaution against reverse tabnabbing. For more information, please refer to the following article:
https://www.jitbit.com/alexblog/256-targetblank---the-most-underestimated-vulnerability-ever/