### PR TITLE
Include locale for categories and Craft Commerce products

### DIFF
--- a/fruitlinkit/fieldtypes/FruitLinkItFieldType.php
+++ b/fruitlinkit/fieldtypes/FruitLinkItFieldType.php
@@ -89,6 +89,7 @@ class FruitLinkItFieldType extends BaseFieldType
                 'sources' => $settings->categorySources,
                 'criteria' => array(
                     'status' => null,
+                    'locale' => $locale,
                 ),
                 'sourceElementId' => ( isset($this->element->id) ? $this->element->id : null ),
                 'limit' => 1,
@@ -101,6 +102,7 @@ class FruitLinkItFieldType extends BaseFieldType
                 'sources' => $settings->productSources,
                 'criteria' => array(
                     'status' => null,
+                    'locale' => $locale,
                 ),
                 'sourceElementId' => ( isset($this->element->id) ? $this->element->id : null ),
                 'limit' => 1,

--- a/fruitlinkit/models/FruitLinkIt_LinkModel.php
+++ b/fruitlinkit/models/FruitLinkIt_LinkModel.php
@@ -264,7 +264,8 @@ class FruitLinkIt_LinkModel extends BaseModel
         if(!$this->_category)
         {
             $id = is_array($this->value) ? $this->value[0] : false;
-            if( $id && $category = craft()->categories->getCategoryById($id) )
+            $locale = isset($this->locale) ? $this->locale : null;
+            if( $id && $category = craft()->categories->getCategoryById($id, $locale) )
             {
                 $this->_category = $category;
             }
@@ -282,7 +283,8 @@ class FruitLinkIt_LinkModel extends BaseModel
         if(!$this->_product)
         {
             $id = is_array($this->value) ? $this->value[0] : false;
-            if( $id && $product = craft()->commerce_products->getProductById($id) )
+            $locale = isset($this->locale) ? $this->locale : null;
+            if( $id && $product = craft()->commerce_products->getProductById($id, $locale) )
             {
 
                 $this->_product = $product;


### PR DESCRIPTION
On one of our websites we encountered an issue with linkit not using the right locale when selecting a category link type. After some digging I found out about [PR 38](https://github.com/fruitstudios/linkit/pull/38) which fixes this for assets and entries.

This PR extends work from PR 38 to include locale-aware category and product selection.